### PR TITLE
Added error handling and updated co

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,24 +1,35 @@
 var co = require('co');
 var each = require('co-each');
 var methods = require('methods');
+
 var isGenerator = function(f) {
 	return typeof f === 'function' && Object.getPrototypeOf(f) !== Object.getPrototypeOf(Function);
 };
+
+var getErrorHandler = function(next) {
+	return function(err) {
+		if (err) next(err);
+	}
+};
+
 var getMiddleware = function (gen) {
 	return !isGenerator(gen) ? gen : function (req, res, next) {
-		return co(gen, req, res, next);
+		return co(gen(req, res, next), getErrorHandler(next));
 	};
 };
+
 var routeWrapper = function (route, context) {
 	return function (path) {
 		var generators = Array.prototype.slice.call(arguments, 1);
 		return route.apply(context, [path].concat(each(generators, getMiddleware)));
 	};
 };
+
 module.exports = function (app) {
 	for (var i = 0; i < methods.length; i++) {
 		var method = methods[i];
 		app[method] = routeWrapper(app[method], app);
 	}
+
 	return app;
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "co-express",
   "description": "An express wrapper that enables generators to be used as middlewares",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "Martín Ciparelli",
     "email": "mciparelli@gmail.com"
@@ -13,7 +13,7 @@
     }
   ],
   "dependencies": {
-    "co": "1.4.1",
+    "co": "1.5.2",
     "co-each": "0.1.0",
     "methods": "0.0.1"
   },
@@ -32,10 +32,16 @@
   },
   "main": "index",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha --harmony"
   },
   "engines": {
     "node": ">=v0.11.4"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "supertest": "~0.7.1",
+    "mocha": "~1.12.1",
+    "express": "~3.4.0",
+    "should": "~1.2.2"
+  }
 }

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -1,0 +1,58 @@
+var express = require('express'),
+    wrapper = require('../index'),
+    co = require('co'),
+    should = require('should'),
+    request = require('supertest');
+
+var thunk = co.wrap(function(err, cb) {
+  cb(err, 'thunk');
+});
+
+describe('co-express', function() {
+  it('supports multiple generator/function routes', function(done) {
+    var app = wrapper(express());
+
+    app.get('/', function*(req, res, next) {
+      req.val = yield thunk(null);
+      next();
+    }, function*(req, res, next) {
+      req.val += yield thunk(null);
+      next();
+    }, function(req, res) {
+      res.send(req.val + 'func');
+    });
+
+    request(app)
+      .get('/')
+      .end(function(err, res) {
+        should.not.exist(err);
+        res.text.should.equal('thunkthunkfunc');
+        done();
+      });
+  });
+
+  it('passes uncaught exceptions', function(done) {
+    var app = wrapper(express());
+
+    app.get('/', function*(req, res, next) {
+      var val = yield thunk(new Error('thunk error'));
+      res.send(val);
+    });
+
+    app.use(function(err, req, res, next) {
+      if (err && err.message === 'thunk error') {
+        res.send('caught');
+      } else {
+        next(err);
+      }
+    });
+
+    request(app)
+      .get('/')
+      .end(function(err, res) {
+        should.not.exist(err);
+        res.text.should.equal('caught');
+        done();
+      });
+  });
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--reporter spec
+--bail


### PR DESCRIPTION
I updated co to 1.5.2 and added an error handler to pass uncaught exceptions to next(). Just ignore my test case if you don't care for mocha.
