### PR TITLE
Readme: recommend mz/fs instead of co-fs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@
 Like this:
 
 ```js
-var fs = require('co-fs');
+var fs = require('mz/fs');
 var express = require('express');
 var wrap = require('co-express');
 


### PR DESCRIPTION
Even `co` itself now recommends mz: https://www.npmjs.com/package/co#associated-libraries